### PR TITLE
(microsoft-windows-terminal) Install package for all users

### DIFF
--- a/automatic/microsoft-windows-terminal/tools/chocolateyInstall.ps1
+++ b/automatic/microsoft-windows-terminal/tools/chocolateyInstall.ps1
@@ -37,4 +37,4 @@ if ($AppxVer -gt [version]$version) {
   }
 }
 
-Add-AppxPackage -Path $fileName
+DISM.EXE /Online /Add-ProvisionedAppxPackage /PackagePath:$fileName /SkipLicense


### PR DESCRIPTION
Tested in my environment, based on comment http://disq.us/p/2rbt5la in Chocolatey package page


## Description
Changed installation line, the list line in chocolateyInstall.ps1

## Motivation and Context
This is required to use this with Puppet and domain controlled account.  
This is also an issue, https://github.com/mkevenaar/chocolatey-packages/issues/152

## How Has this Been Tested?
Tested in my environment, where I have Foreman controlling puppet which is used to control Windows workstations. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [X] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
